### PR TITLE
Fix dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ default = ["glam"]
 glam = ["ilattice/glam"]
 
 [dependencies]
-ilattice = { git = "https://github.com/bonsairobo/ilattice-rs", branch = "main", default-features = false }
+ilattice = { git = "https://github.com/bonsairobo/ilattice-rs", rev = "30b6b463", default-features = false }


### PR DESCRIPTION
This change tries to fix 2 problems:

1. Incompatible changes in ilattice will break dependent crates.
2. Feldspar-map breaks due to pulling ilattice twice.

When compiling feldspar-map, try `cargo tree`:

```
├── feldspar-core v0.1.0 (/home/hacker/voxel/feldspar/crates/feldspar-core)
│   ├── ilattice v0.1.0 (https://github.com/bonsairobo/ilattice-rs?rev=30b6b463#30b6b463)
│   │   ├── glam v0.20.5
├── feldspar-map v0.1.0 (/home/hacker/voxel/feldspar/crates/feldspar-map)
│   ├── feldspar-core v0.1.0 (/home/hacker/voxel/feldspar/crates/feldspar-core) (*)
│   ├── grid-ray v0.1.0 (https://github.com/bonsairobo/grid-ray-rs?rev=0fd6c561#0fd6c561)
│   │   └── ilattice v0.4.0 (https://github.com/bonsairobo/ilattice-rs?branch=main#9f760417)
│   │       └── glam v0.23.0
```

This pulls 2 versions of ilattice, which pull 2 versions of glam. As a result, a clean build of feldspar-map fails:

```
error[E0277]: the trait bound `grid_tree::glam::Vec3A: grid_ray::ilattice::vector::FloatVector` is not satisfied
   --> crates/feldspar-map/src/chunk.rs:149:24
    |
149 |             let iter = GridRayIter3::new(nudge_start, ray.velocity());
    |                        ^^^^^^^^^^^^^^^^^ the trait `grid_ray::ilattice::vector::FloatVector` is not implemented for `grid_tree::glam::Vec3A`
    |
    = help: the following other types implement trait `grid_ray::ilattice::vector::FloatVector`:
              grid_ray::ilattice::glam::Vec3
              grid_ray::ilattice::prelude::Vec2
              grid_ray::ilattice::prelude::Vec3A
note: required by a bound in `GridRayIter3::<Vi, Vf>::new`
   --> /home/foo/.cargo/git/checkouts/grid-ray-rs-342c48316e839b58/0fd6c56/src/lib.rs:63:9
    |
63  |     Vf: FloatVector<Int = Vi> + SignedVector,
    |         ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `GridRayIter3::<Vi, Vf>::new`
```

This change tries to fix it by hardcoding the same revision as is being used by feldspar-core.

I think this is actually not the right solution. The bug is in feldspar-core, where it fails to convert types from one glam version (through feldspar-core) to the other (through grid-ray). I tried to do this manually, but I got hit by some recursive generic resolution error when I tried `GridRayIter3::<grid_ray::ilattice::glam::Vec3, grid_ray::ilattice::glam::Vec3>::new()` D:.

Have you considered gathering some of those crates in a single repository to make updating their dependencies at the same time easier? As it is, I find that I have to fork them a lot just to synchronize the versions.